### PR TITLE
Add typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,70 @@
+// Type definitions for webpack-plugin-compat@1.0.1
+// Project: https://github.com/chuckdumont/webpack-plugin-compat
+// Definitions by: Chuck Dumont <chuckd@pnp-hcl.com>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare const webpackPluginCompat: WebpackPluginCompat;
+
+type HookType = 'Sync'
+  | 'SyncBail'
+  | 'SyncWaterfall'
+  | 'AsyncSeries'
+  | 'AsyncSeriesWaterfall'
+  | 'AsyncParalell'
+  | 'AsyncParallelBail';
+
+type HookCallback = (...args: any[]) => any;
+
+type HookCallFn = (plugin: Tapable, eventName: string, ...args: any[]) => void;
+
+interface HookTypeAndArgNames {
+  [index: number]: string;
+  0: HookType;
+}
+
+type Tapable = any;
+
+interface WebpackPluginCompat extends WebpackPluginCompatCommon {
+  for(pluginName: string): WebpackPluginCompatFor;
+}
+
+interface WebpackPluginCompatCommon {
+  Tapable: Tapable;
+  reg(
+    obj: Tapable,
+    hookName: string,
+    hookTypeAndArgNames: HookTypeAndArgNames,
+  ): void;
+  reg(
+    obj: Tapable,
+    hookMap: { [hookName: string]: HookTypeAndArgNames },
+  ): void;
+  callSync: HookCallFn;
+  callSyncBail: HookCallFn;
+  callSyncWaterfall: HookCallFn;
+  callAsyncSeries: HookCallFn;
+  callAsyncSeriesWaterfall: HookCallFn;
+  callAsyncParallel: HookCallFn;
+  callAsyncParallelBail: HookCallFn;
+}
+
+interface WebpackPluginCompatFor extends WebpackPluginCompatCommon {
+  tap(
+    obj: Tapable,
+    eventName: string,
+    callback: HookCallback,
+    context?: any,
+  ): void;
+  tap(
+    obj: Tapable,
+    eventMap: { [eventName: string]: HookCallback },
+    context?: any,
+  ): void;
+  tap(
+    obj: Tapable,
+    eventArr: ([ string | string[], HookCallback ])[],
+    context?: any,
+  ): void;
+}
+
+export = webpackPluginCompat;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-plugin-compat",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "webpack-plugin-compat",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Compatibility layer for webpack V3/V4 plugin APIs",
   "main": "index.js",
+  "typings": "index.d.ts",
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
How about add typescript definition?

For information, I'm [written this definition for your package 2 years ago](https://github.com/enten/udk/blob/8b3312f0ee62b85d3d756d71c4d9e96a024e393e/types/webpack-plugin-compat/index.d.ts).

And that still works with your latest package version (v1.0.4) published yesterday.

If you want to add a unit test for testing the definition: tell me and I will do that.